### PR TITLE
feat: allow use of HTML in predefined messages

### DIFF
--- a/data/config.yaml
+++ b/data/config.yaml
@@ -12,7 +12,7 @@ telegram:
 # -------------------------------- MESSAGES --------------------------------- #
 
 messages:
-  affiliate_link_modified: "Here is the modified link with our affiliate program"
+  affiliate_link_modified: "<i>Here is the modified link with our affiliate program</i>"
   reply_provided_by_user: "Reply provided by"
   discount_keywords:
     - discounts


### PR DESCRIPTION
**Example**

With config.yaml like:

```yaml
...
messages:
  affiliate_link_modified: "<i>Enlace modificado por el programa de afiliados para mantener el proyecto.</i>"
...
```

We get this format:

![image](https://github.com/user-attachments/assets/5669833e-a38d-4f52-942a-2a4823fa2a96)
