### PR TITLE
bug: Aliexpress codes showed two times

### DIFF
--- a/handlers/pattern_handler.py
+++ b/handlers/pattern_handler.py
@@ -1,5 +1,6 @@
 from handlers.base_handler import BaseHandler
-from handlers.patterns import PATTERNS  
+from handlers.patterns import PATTERNS
+
 
 class PatternHandler(BaseHandler):
     def __init__(self):
@@ -13,13 +14,12 @@ class PatternHandler(BaseHandler):
             format_template=data["format_template"],
             affiliate_tag=data["affiliate_tag"],
         )
-    
+
     async def handle_links(self, context) -> bool:
         """Handles links based on the platform's patterns."""
-        
-        processed = False 
-        for platform, data in PATTERNS.items():
-            processed=await self.process_affiliate_link(context, platform, data)
 
-        return processed 
- 
+        processed = False
+        for platform, data in PATTERNS.items():
+            processed |= await self.process_affiliate_link(context, platform, data)
+
+        return processed


### PR DESCRIPTION
When handled by awin, the true state of processed is lost and then enters later in the aliexpress_handler showing the codes again