### PR TITLE
bug: addon is not sending the creator percentage

### DIFF
--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,5 +1,5 @@
 name: "Botaffiumeiro"
-version: "2.1.3.0"
+version: "2.1.3.1"
 slug: "botaffiumeiro"
 description: "Modify Telegram links with affiliate links"
 url: "https://github.com/hectorzin/botaffiumeiro/tree/main/ha-addon"

--- a/ha-addon/json2yaml.py
+++ b/ha-addon/json2yaml.py
@@ -60,7 +60,9 @@ config = {
         ),
     },
     "log_level": data.get("log_level", "INFO"),
-    "creator_affiliate_percentage": data.get("creator_affiliate_percentage", 10),
+    "affiliate_settings": {
+        "creator_affiliate_percentage": data.get("creator_affiliate_percentage", 10),
+    }
 }
 
 # Save the YAML file


### PR DESCRIPTION
This causes Botaffiumeiro to use always default 10%