### PR TITLE
Ha_addon_missing_fields

### DIFF
--- a/ha-addon/README.md
+++ b/ha-addon/README.md
@@ -113,7 +113,6 @@ A list of domains and ids per domain:
 ### 8. Support for creators
 
 - **creator_affiliate_percentage**: This parameter allows you to define what percentage of the links shared in Telegram groups will be replaced with affiliate links belonging to the software creators. However, there are a few important conditions to keep in mind:
-
   1. **Available Affiliate Links**: Only links that the software creators have affiliate programs for will be eligible to be replaced.
 
   2. **Affiliate Priority**: If the user does not have an affiliate link for a specific domain, but the creators of the software do, the creators' affiliate link will be used instead.

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -14,10 +14,34 @@ startup: services
 options:
   bot_token: ""
   delete_messages: true
+  excluded_users:
+    - id: ""
+  discount_keywords:
+    - key: ""
   msg_affiliate_link_modified: "Here is the modified link with our affiliate program:"
   msg_reply_provided_by_user: "Reply provided by"
+  amazon:
+    - domain: ""
+      id: ""
+  aliexpress_app_key: ""
+  aliexpress_app_secret: ""
+  aliexpress_tracking_id: ""
+  aliexpress_discount_codes:
+    - line: ""
+  awin_publisher_id: ""
+  awin_adversiters:
+    - domain: ""
+      id: ""
+  admitad_publisher_id: ""
+  admitad_adversiters:
+    - domain: ""
+      id: ""
+  tradedoubler_publisher_id: ""
+  tradedoubler_adversiters:
+    - domain: ""
+      id: ""
   creator_affiliate_percentage: "10"
-  log_level: INFO
+  log_level: "INFO"
 schema:
   bot_token: str
   delete_messages: bool?

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,5 +1,5 @@
 name: "Botaffiumeiro"
-version: "2.1.6.0"
+version: "2.1.6.1"
 slug: "botaffiumeiro"
 description: "Modify Telegram links with affiliate links"
 url: "https://github.com/hectorzin/botaffiumeiro/tree/main/ha-addon"


### PR DESCRIPTION
Algo ha cambiado en HA, que antes con poner solo la parte de schema funcionaba, y ahora necesita además estar todo en options